### PR TITLE
Release 0.3.4

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run Changelog CI
-        uses: saadmk11/changelog-ci@v0.6.1
+        uses: saadmk11/changelog-ci@v0.8.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:

--- a/.release
+++ b/.release
@@ -1,3 +1,3 @@
 # This file is used to trigger the release for the changelog-ci
 
-2020-12-08: 0.3.3
+2021-05-27: 0.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 * [#25](https://github.com/greymatter-io/gmenv/pull/25): Update version url pattern and introduce backwards-compatible fetching
 
+# Version: 0.3.4
+
+#### Bug Fixes
+* [#32](https://github.com/greymatter-io/gmenv/pull/32): Fixes the sort when
+    calling list-remote
+
 
 # Version 0.3.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
 This repo uses [changelog-ci](https://github.com/saadmk11/changelog-ci) to
-automatically keep a Change Log. When you're ready to snap a release, the commit
-message for the last commit needs to be of the format "Release X.Y.Z". This will
+automatically keep a Change Log. When you're ready to snap a release, the title
+of the PR needs to be of the format "Release X.Y.Z". This will
 trigger the CI to properly build the changelog.
 
 The release will occur when the appropriate tag is pushed to the repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+This repo uses [changelog-ci](https://github.com/saadmk11/changelog-ci) to
+automatically keep a Change Log. When you're ready to snap a release, the commit
+message for the last commit needs to be of the format "Release X.Y.Z". This will
+trigger the CI to properly build the changelog.
+
+The release will occur when the appropriate tag is pushed to the repo.

--- a/libexec/gmenv-list-remote
+++ b/libexec/gmenv-list-remote
@@ -48,7 +48,7 @@ fi;
 for dir in libexec bin; do
   case ":${PATH}:" in
     *:${GMENV_ROOT}/${dir}:*) log 'debug' "\$PATH already contains '${GMENV_ROOT}/${dir}', not adding it again";;
-    *) 
+    *)
       log 'debug' "\$PATH does not contain '${GMENV_ROOT}/${dir}', prepending and exporting it now";
       export PATH="${GMENV_ROOT}/${dir}:${PATH}";
       ;;
@@ -95,4 +95,4 @@ if [ "${versions}" == "" ]; then
   exit 1;
 fi
 
-echo "${versions}"
+echo "${versions}" | sort


### PR DESCRIPTION
>Going to try this again to kick off the CI properly. If it doesn't work this time I'll just manually make the changes.

This update sorts the return from the `gmenv list-remote` command.

Prior version:
```
➜  gmenv git:(sort) gmenv list-remote
0.1.0
0.2.0
0.3.0
0.4.0
0.4.1
0.5.0
0.5.1
1.0.0
2.0.0
2.0.1
2.0.2
1.0.1
1.0.2
1.0.3
1.1.0
1.2.1
1.4.1
1.4.2
➜  gmenv git:(sort)
```

Updated list:
```
➜  gmenv git:(sort) ./bin/gmenv list-remote
0.1.0
0.2.0
0.3.0
0.4.0
0.4.1
0.5.0
0.5.1
1.0.0
1.0.1
1.0.2
1.0.3
1.1.0
1.2.1
1.4.1
1.4.2
2.0.0
2.0.1
2.0.2
➜  gmenv git:(sort)
```
